### PR TITLE
Readme: use https for security

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Purpose
 The github.com/nasa organizational account is intended to publicly host NASA code that has been SRA-approved for open source. 
 
-# IF YOU ARE LOOKING FOR INFORMATION, PLEASE CHECK OUT THE GITHUB PAGES PAGE CREATED BY THIS REPO http://nasa.github.io/
+# IF YOU ARE LOOKING FOR INFORMATION, PLEASE CHECK OUT THE GITHUB PAGES PAGE CREATED BY THIS REPO https://nasa.github.io/
 
-<!-- <b><i>If you are a NASA staff member, please check out these instructions for adding a code repository or getting made a collaborator: http://nasa.github.io/</i></b> -->
+<!-- <b><i>If you are a NASA staff member, please check out these instructions for adding a code repository or getting made a collaborator: https://nasa.github.io/</i></b> -->
 
 ## Visualizations of NASA Code
 An exploration of user engagement with NASA code repositories. Use this to find out which code has active development and might be good place to submit a pull request! https://observablehq.com/@justingosses/public-engagement-with-nasas-open-source-code-projects-on-g?collection=@justingosses/nasa-metadata
@@ -17,7 +17,7 @@ We currently have two active owners in the org:
 + Taylor Yates (evan.t.yates@nasa.gov)
 + Justin Gosses (justin.c.gosses@nasa.gov)
 
-Please reach out to us if you have any questions not covered in http://nasa.github.io/ or https://code.nasa.gov/#/guide
+Please reach out to us if you have any questions not covered in https://nasa.github.io/ or https://code.nasa.gov/#/guide
 
 <!-- ## Related Information & Sites
 


### PR DESCRIPTION
## Changes in this PR

+ Updates readme.md to use https for security when linking to site hosted on GitHub

## Notes

+ The link in the [description of this repo](https://github.com/nasa/nasa.github.io) should also be updated
<img width="290" alt="Screen Shot 2021-03-19 at 16 40 05" src="https://user-images.githubusercontent.com/1041600/111834339-3940f480-88d2-11eb-9886-09c15e58c6f8.png">


+ The link in the [GitHub profile](https://github.com/nasa) should also be updated
<img width="343" alt="Screen Shot 2021-03-19 at 16 40 50" src="https://user-images.githubusercontent.com/1041600/111834349-3c3be500-88d2-11eb-97f3-21f2c7906d44.png">

