### PR TITLE
Fixed Typo mistake for member

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
             request
             (<a href="https://nams.nasa.gov">https://nams.nasa.gov</a>).
             If you were a member several years ago and recently found you are no
-            longer a meember, please see this 
+            longer a member, please see this 
             <a href="https://github.com/nasa/nasa.github.io/issues/2">note</a>.
         </p>
         <p>


### PR DESCRIPTION
The `member` word was written as `meember`.